### PR TITLE
chore: don't checkout the code when running the bot

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -2,11 +2,9 @@ on:
   issue_comment:
     types: [created]
 jobs:
-  test:
+  bot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      # - uses: ./
       - uses: publiccodeyml/bot@main
         with:
           username: yaml-9000


### PR DESCRIPTION
Checking out the code to run the bot action is not needed.