### PR TITLE
fix: make next vote date inclusive of today

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8972,12 +8972,14 @@ exports.reactToComment = reactToComment;
 function getNextVoteDate() {
     const now = new Date();
     const year = now.getFullYear();
+    // Today at 00:00. We compare dates (not times).
+    const today = new Date(year, now.getMonth(), now.getDate());
     const schedule = [
         new Date(year, 0 /* Jan */, 30),
         new Date(year, 4 /* May */, 30),
         new Date(year, 8 /* Sep */, 30),
     ];
-    const next = schedule.find(d => d > now);
+    const next = schedule.find(d => d > today);
     const nextDate = next !== null && next !== void 0 ? next : new Date(year + 1, schedule[0].getMonth(), schedule[0].getDate());
     return nextDate.toLocaleDateString('en-US', {
         month: 'long',

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -67,13 +67,16 @@ function getNextVoteDate() {
   const now = new Date();
   const year = now.getFullYear();
 
+  // Today at 00:00. We compare dates (not times).
+  const today = new Date(year, now.getMonth(), now.getDate());
+
   const schedule = [
     new Date(year, 0 /* Jan */, 30),
     new Date(year, 4 /* May */, 30),
     new Date(year, 8 /* Sep */, 30),
   ];
 
-  const next = schedule.find(d => d > now);
+  const next = schedule.find(d => d > today);
   const nextDate = next ?? new Date(year + 1, schedule[0]!.getMonth(), schedule[0]!.getDate());
 
   return nextDate.toLocaleDateString('en-US', {


### PR DESCRIPTION
Normalize the current date to 00:00 so the comparison is day based.

This should have said "Jan 30":
https://github.com/publiccodeyml/publiccode.yml/pull/288#issuecomment-3822616556