### PR TITLE
fix: handle 404 gracefully when a governance team does not exist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8939,8 +8939,17 @@ function getCommandsFromComment(body) {
 exports.getCommandsFromComment = getCommandsFromComment;
 function inTeam(org, username, team) {
     return __awaiter(this, void 0, void 0, function* () {
-        const members = yield octokit_1.default.teams.listMembersInOrg({ org, team_slug: team });
-        return members.data.map(m => m.login).includes(username);
+        try {
+            const members = yield octokit_1.default.teams.listMembersInOrg({ org, team_slug: team });
+            return members.data.map(m => m.login).includes(username);
+        }
+        catch (e) {
+            if (e.status === 404) {
+                console.warn(`404 while fetching members of '${team}' team`);
+                return false;
+            }
+            throw e;
+        }
     });
 }
 exports.inTeam = inTeam;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8945,7 +8945,7 @@ function inTeam(org, username, team) {
         }
         catch (e) {
             if (e.status === 404) {
-                console.warn(`404 while fetching members of '${team}' team`);
+                console.error(`404 while fetching members of '${team}' team`);
                 return false;
             }
             throw e;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -45,7 +45,7 @@ export async function inTeam(org: string, username: string, team: string) {
     return members.data.map(m => m.login).includes(username);
   } catch (e) {
     if ((e as RequestError).status === 404) {
-      console.warn(`404 while fetching members of '${team}' team`);
+      console.error(`404 while fetching members of '${team}' team`);
       return false;
     }
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -39,9 +39,18 @@ export function getCommandsFromComment(body: string): Command[] {
 }
 
 export async function inTeam(org: string, username: string, team: string) {
-  const members = await octokit.teams.listMembersInOrg({ org, team_slug: team });
+  try {
+    const members = await octokit.teams.listMembersInOrg({ org, team_slug: team });
 
-  return members.data.map(m => m.login).includes(username);
+    return members.data.map(m => m.login).includes(username);
+  } catch (e) {
+    if ((e as RequestError).status === 404) {
+      console.warn(`404 while fetching members of '${team}' team`);
+      return false;
+    }
+
+    throw e;
+  }
 }
 
 export async function isMaintainer(org: string, username: string) {


### PR DESCRIPTION
The bot crashes with an unhandled RequestError (404) when calling listMembersInOrg for a team that doesn't exist in the org. This causes every comment on every issue to trigger a failing action run.

The fix follows the same pattern already used in removeLabel in the same file: catch the 404, log a warning, and return false (not a member) instead of throwing. Any other error is still re-thrown. The RequestError type needed for the cast is already imported.

Fixes the failure visible in [https://github.com/publiccodeyml/publiccode.yml/acti](https://github.com/publiccodeyml/publiccode.yml/actions/runs/26639343572/job/78507847772)