### PR TITLE
feat: include every reaction in the vote log

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9618,15 +9618,7 @@ function buildUpdatedComment(body, newLines, newState) {
     return `${withoutMarker}\n${newLines.join('\n')}\n\n${stateMarker}`;
 }
 exports.buildUpdatedComment = buildUpdatedComment;
-function steeringCommitteeMembers() {
-    return __awaiter(this, void 0, void 0, function* () {
-        return (yield octokit_1.default.teams.listMembersInOrg({
-            org: 'publiccodeyml',
-            team_slug: 'steering-committee',
-        })).data.map(m => m.login);
-    });
-}
-function syncIssueVoteLog(owner, repo, issueNumber, members) {
+function syncIssueVoteLog(owner, repo, issueNumber) {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const comments = yield octokit_1.default.paginate('GET /repos/:owner/:repo/issues/:issue_number/comments', { owner, repo, issue_number: issueNumber });
@@ -9643,9 +9635,8 @@ function syncIssueVoteLog(owner, repo, issueNumber, members) {
             repo,
             comment_id: voteComment.id,
         });
-        const committee = members !== null && members !== void 0 ? members : yield steeringCommitteeMembers();
         const liveReactions = reactions.data
-            .filter(r => { var _a, _b; return (r.content === '+1' || r.content === '-1') && committee.includes((_b = (_a = r.user) === null || _a === void 0 ? void 0 : _a.login) !== null && _b !== void 0 ? _b : ''); })
+            .filter(r => r.content === '+1' || r.content === '-1')
             .map(r => ({
             login: r.user.login,
             content: r.content,
@@ -9673,8 +9664,7 @@ function run(owner, repo) {
         const issues = yield octokit_1.default.paginate('GET /repos/:owner/:repo/issues', {
             owner, repo, state: 'open', labels: 'vote-start',
         });
-        const members = yield steeringCommitteeMembers();
-        yield Promise.all(issues.map(issue => syncIssueVoteLog(owner, repo, issue.number, members)));
+        yield Promise.all(issues.map(issue => syncIssueVoteLog(owner, repo, issue.number)));
     });
 }
 exports["default"] = run;

--- a/src/commands/voteSync.ts
+++ b/src/commands/voteSync.ts
@@ -91,18 +91,10 @@ export function buildUpdatedComment(
   return `${withoutMarker}\n${newLines.join('\n')}\n\n${stateMarker}`;
 }
 
-async function steeringCommitteeMembers(): Promise<string[]> {
-  return (await octokit.teams.listMembersInOrg({
-    org: 'publiccodeyml',
-    team_slug: 'steering-committee',
-  })).data.map(m => m.login);
-}
-
 export async function syncIssueVoteLog(
   owner: string,
   repo: string,
   issueNumber: number,
-  members?: string[],
 ): Promise<void> {
   const comments = await octokit.paginate(
     'GET /repos/:owner/:repo/issues/:issue_number/comments',
@@ -125,10 +117,8 @@ export async function syncIssueVoteLog(
     comment_id: voteComment.id,
   });
 
-  const committee = members ?? await steeringCommitteeMembers();
-
   const liveReactions: LiveReaction[] = reactions.data
-    .filter(r => (r.content === '+1' || r.content === '-1') && committee.includes(r.user?.login ?? ''))
+    .filter(r => r.content === '+1' || r.content === '-1')
     .map(r => ({
       login: r.user!.login,
       content: r.content as '+1' | '-1',
@@ -163,7 +153,5 @@ export default async function run(owner: string, repo: string): Promise<void> {
     },
   ) as Array<{ number: number }>;
 
-  const members = await steeringCommitteeMembers();
-
-  await Promise.all(issues.map(issue => syncIssueVoteLog(owner, repo, issue.number, members)));
+  await Promise.all(issues.map(issue => syncIssueVoteLog(owner, repo, issue.number)));
 }


### PR DESCRIPTION
For completeness the log lists everyone who reacted, not just the steering committee, so the comment is a full record of the thumbs up and down. The vote-end count is unchanged.